### PR TITLE
:bug: fix type hints in prod

### DIFF
--- a/hooks_lib/aws_api.py
+++ b/hooks_lib/aws_api.py
@@ -1,22 +1,30 @@
 import logging
 import operator
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from boto3 import Session
 from botocore.config import Config
-from mypy_boto3_ec2.client import EC2Client
-from mypy_boto3_ec2.type_defs import SecurityGroupTypeDef
-from mypy_boto3_ec2.type_defs import SubnetTypeDef as EC2SubnetTypeDef
-from mypy_boto3_elasticache.client import ElastiCacheClient
-from mypy_boto3_elasticache.literals import UpdateActionStatusType
-from mypy_boto3_elasticache.type_defs import (
-    ProcessedUpdateActionTypeDef,
-    UpdateActionTypeDef,
-)
-from mypy_boto3_elasticache.type_defs import (
-    SubnetTypeDef as ElasticacheSubnetTypeDef,
-)
+
+if TYPE_CHECKING:
+    from mypy_boto3_ec2.client import EC2Client
+    from mypy_boto3_ec2.type_defs import SecurityGroupTypeDef
+    from mypy_boto3_ec2.type_defs import SubnetTypeDef as EC2SubnetTypeDef
+    from mypy_boto3_elasticache.client import ElastiCacheClient
+    from mypy_boto3_elasticache.literals import UpdateActionStatusType
+    from mypy_boto3_elasticache.type_defs import (
+        ProcessedUpdateActionTypeDef,
+        UpdateActionTypeDef,
+    )
+    from mypy_boto3_elasticache.type_defs import (
+        SubnetTypeDef as ElasticacheSubnetTypeDef,
+    )
+else:
+    EC2Client = SecurityGroupTypeDef = EC2SubnetTypeDef = ElastiCacheClient = (
+        UpdateActionStatusType
+    ) = ProcessedUpdateActionTypeDef = UpdateActionTypeDef = (
+        ElasticacheSubnetTypeDef
+    ) = object
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix

```
Running hook: pre_hook
Traceback (most recent call last):
  File "/home/app/src/./hooks/pre_hook.py", line 10, in <module>
    from hooks_lib import ServiceUpdatesManager
  File "/home/app/src/hooks_lib/__init__.py", line 1, in <module>
    from .service_updates import ServiceUpdatesManager
  File "/home/app/src/hooks_lib/service_updates.py", line 7, in <module>
    from hooks_lib.aws_api import AWSApi
  File "/home/app/src/hooks_lib/aws_api.py", line 8, in <module>
    from mypy_boto3_ec2.client import EC2Client
ModuleNotFoundError: No module named 'mypy_boto3_ec2'
```