### PR TITLE
:sparkles: Valkey support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-cdktf-main/er-base-cdktf-main:cdktf-0.20.11-tf-1.6.6-py-3.11-v0.5.0-1@sha256:0c6f11a1a4057ceb6ea9fb9f5ec7eb0a5a2bdf7730416cbddda87b0f509e59a5 AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.3.0"
+LABEL konflux.additional-tags="0.3.1"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f /uv /bin/uv

--- a/er_aws_elasticache/app_interface_input.py
+++ b/er_aws_elasticache/app_interface_input.py
@@ -147,6 +147,23 @@ class ElasticacheData(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def no_older_versions_for_valkey(self) -> Self:
+        """Check for Valkey engine version."""
+        if self.engine == "valkey" and self.engine_version.startswith(("5.", "6.")):
+            raise ValueError("Valkey requires an engine_version 7.2 or higher")
+        return self
+
+    @model_validator(mode="after")
+    def check_parameter_group_family(self) -> Self:
+        """Check if the parameter group family matches the engine"""
+        family = f"{self.engine}{self.engine_version[0]}"
+        if self.parameter_group and family not in self.parameter_group.family:
+            raise ValueError(
+                f"Parameter group family must match the engine. Expected {family}, got {self.parameter_group.family}"
+            )
+        return self
+
 
 class AppInterfaceInput(BaseModel):
     """Input model for AWS Elasticache"""


### PR DESCRIPTION
Support the [valkey](https://aws.amazon.com/elasticache/what-is-valkey/) engine.

Actions supported:
* Cluster creation
* Cluster deletion
* Cluster upgrade from Valkey and Redis

Depends on: https://github.com/app-sre/qontract-schemas/pull/765
Ticket: [APPSRE-11041](https://issues.redhat.com/browse/APPSRE-11041)