### PR TITLE
:coffin: remove special tekton configs

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -30,27 +30,6 @@ spec:
     value: .
   - name: target-stage
     value: test
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    # - linux-m2xlarge/arm64
-  taskRunSpecs:
-  - pipelineTaskName: build-container
-    stepSpecs:
-    - name: build
-      computeResources:
-        requests:
-          memory: 20Gi
-        limits:
-          memory: 20Gi
-  - pipelineTaskName: ecosystem-cert-preflight-checks
-    stepSpecs:
-    - name: check-container
-      computeResources:
-        requests:
-          memory: 4Gi
-        limits:
-          memory: 4Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -27,27 +27,6 @@ spec:
     value: .
   - name: target-stage
     value: prod
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    # - linux-m2xlarge/arm64
-  taskRunSpecs:
-  - pipelineTaskName: build-container
-    stepSpecs:
-    - name: build
-      computeResources:
-        requests:
-          memory: 20Gi
-        limits:
-          memory: 20Gi
-  - pipelineTaskName: ecosystem-cert-preflight-checks
-    stepSpecs:
-    - name: check-container
-      computeResources:
-        requests:
-          memory: 4Gi
-        limits:
-          memory: 4Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
After the switch to base 0.6.0 we don't need to increase the tekton resources anymore.