### PR TITLE
:sparkles: service_updates_types setting

### DIFF
--- a/er_aws_elasticache/app_interface_input.py
+++ b/er_aws_elasticache/app_interface_input.py
@@ -58,6 +58,12 @@ class ElasticacheData(BaseModel):
     # service updates related
     environment: str = "production"
     service_updates_enabled: bool = True
+    service_updates_types: Sequence[str] = [
+        "engine-update",
+        "security-update",
+        # we don't want to run major engine updates by default
+        # 'engine-major-version-update'
+    ]
     service_updates_severities: Sequence[str] = ["critical", "important"]
     service_updates_cooldown_days: int | None = None
 

--- a/hooks/post_apply.py
+++ b/hooks/post_apply.py
@@ -58,6 +58,7 @@ def main(
     )
 
     service_updates = sumgr.service_updates(
+        service_updates_types=app_interface_input.data.service_updates_types,
         severities=app_interface_input.data.service_updates_severities,
         released_before=dt.now(tz=UTC)
         - timedelta(

--- a/hooks_lib/service_updates.py
+++ b/hooks_lib/service_updates.py
@@ -43,7 +43,10 @@ class ServiceUpdatesManager:
         )
 
     def service_updates(
-        self, severities: Sequence[str], released_before: datetime
+        self,
+        service_updates_types: Sequence[str],
+        severities: Sequence[str],
+        released_before: datetime,
     ) -> list[ServiceUpdate]:
         """Get a list of all available service updates ordered by release date (most recent first)."""
         return [
@@ -58,7 +61,8 @@ class ServiceUpdatesManager:
                 replication_group_id=self.replication_group_id,
                 status=["not-applied", "scheduled", "stopped"],
             )
-            if u["ServiceUpdateSeverity"] in severities
+            if u["ServiceUpdateType"] in service_updates_types
+            and u["ServiceUpdateSeverity"] in severities
             and u["ServiceUpdateReleaseDate"] < released_before
         ]
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -151,6 +151,11 @@ variable "service_updates_severities" {
   default = ["critical", "important"]
 }
 
+variable "service_updates_types" {
+  type    = list(string)
+  default = ["engine-update", "security-update"]
+}
+
 variable "snapshot_retention_limit" {
   type    = number
   default = null
@@ -163,7 +168,7 @@ variable "snapshot_window" {
 
 variable "subnet_group_name" {
   type    = string
-  default = null
+  default = "default"
 }
 
 variable "tags" {


### PR DESCRIPTION
This PR introduces the `service_updates_types` setting to specify which types of ElastiCache service updates are allowed to be applied.
The default setting excludes the `engine-major-version-update` type to avoid any future major engine upgrades like `elasticache-redis-oss-v4-v5-eol-replication-groups`.

Ticket: [APPSRE-12377](https://issues.redhat.com/browse/APPSRE-12377)
Depends on: https://github.com/app-sre/qontract-schemas/pull/917

Links:
* [Redis 5 EOL](https://aws.amazon.com/blogs/database/introducing-extended-support-for-amazon-elasticache-version-4-and-version-5-for-redis-oss/)
